### PR TITLE
Add Wiki Pages for `.wnd` Files and Controls

### DIFF
--- a/documents/wnd/controls/combobox.md
+++ b/documents/wnd/controls/combobox.md
@@ -1,0 +1,348 @@
+# ComboBox Control
+The **ComboBox** control is used for creating a dropdown list. You can define the position, size, and appearance of the <b>ComboBox</b>.
+
+## Available tags
+In addition to the [default control tags](user.md), the following tags are available. Note that each tag is **upper case** only. This is important, as WND tags are case-sensitive.
+
+- The control does not have a `TEXT` tag. Unlike controls such as checkboxes, which include a text label, this control is self-contained and does not display or use a text label.
+
+<small>Click on the links to view available values and options for each tag.</small>
+
+| Tag                                      | Description                                                                  |
+|------------------------------------------|------------------------------------------------------------------------------|
+| `COMBOBOXDATA`                           | Defines specific properties of the ComboBox.                                 |
+| `COMBOBOXDROPDOWNBUTTONENABLEDDRAWDATA`  | Visual texture for the dropdown button of the ComboBox when enabled.         |
+| `COMBOBOXDROPDOWNBUTTONDISABLEDDRAWDATA` | Visual texture for the dropdown button of the ComboBox when disabled.        |
+| `COMBOBOXDROPDOWNBUTTONHILITEDRAWDATA`   | Visual texture for the dropdown button of the ComboBox when highlighted.     |
+| `COMBOBOXEDITBOXENABLEDDRAWDATA`         | Visual texture for the edit box of the ComboBox when enabled.                |
+| `COMBOBOXEDITBOXDISABLEDDRAWDATA`        | Visual texture for the edit box of the ComboBox when disabled.               |
+| `COMBOBOXEDITBOXHILITEDRAWDATA`          | Visual texture for the edit box of the ComboBox when highlighted.            |
+| `LISTBOXENABLEDDRAWDATA`                 | Visual texture for the list box (dropdown options) when enabled.             |
+| `LISTBOXDISABLEDDRAWDATA`                | Visual texture for the list box (dropdown options) when disabled.            |
+| `LISTBOXHILITEDRAWDATA`                  | Visual texture for the list box (dropdown options) when highlighted.         |
+| `LISTBOXENABLEDUPEXBUTTONDRAWDATA`       | Visual texture for the up button of the list box when enabled.               |
+| `LISTBOXDISABLEDUPEXBUTTONDRAWDATA`      | Visual texture for the up button of the list box when disabled.              |
+| `LISTBOXHILITEUPBUTTONDRAWDATA`          | Visual texture for the up button of the list box when highlighted.           |
+| `LISTBOXENABLEDDOWNBUTTONDRAWDATA`       | Visual texture for the down button of the list box when enabled.             |
+| `LISTBOXDISABLEDDOWNBUTTONDRAWDATA`      | Visual texture for the down button of the list box when disabled.            |
+| `LISTBOXHILITEDOWNBUTTONDRAWDATA`        | Visual texture for the down button of the list box when highlighted.         |
+| `LISTBOXENABLEDSLIDERDRAWDATA`           | Visual texture for the slider (scroll bar) in the list box when enabled.     |
+| `LISTBOXDISABLEDSLIDERDRAWDATA`          | Visual texture for the slider (scroll bar) in the list box when disabled.    |
+| `LISTBOXHILITESLIDERDRAWDATA`            | Visual texture for the slider (scroll bar) in the list box when highlighted. |
+| `SLIDERTHUMBENABLEDDRAWDATA`             | Visual texture for the slider thumb (handle) when enabled.                   |
+| `SLIDERTHUMBDISABLEDDRAWDATA`            | Visual texture for the slider thumb (handle) when disabled.                  |
+| `SLIDERTHUMBHILITEDRAWDATA`              | Visual texture for the slider thumb (handle) when highlighted.               |
+
+<small>Note: All tags are case-sensitive.</small>
+
+The following section list the default values and available textures for each tag
+<details>
+  <summary>Click to expand</summary>
+
+### COMBOBOXDATA
+- ISEDITABLEC: 0 = non-editable, 1 = editable
+- MAXCHARSC: Max characters (e.g., 16)
+- MAXDISPLAYC: Max items to display (e.g., 2)
+- ASCIIONLYC: 0 = allows non-ASCII, 1 = only ASCII
+- LETTERSANDNUMBERSC: 0 = allows all characters, 1 = allows only letters and numbers.
+
+### ENABLEDDRAWDATA, DISABLEDDRAWDATA, HILITEDRAWDATA
+- NoImage / NoImage / ListBoxHiliteSelectedItemLeftEnd
+- NoImage / NoImage / ListBoxHiliteSelectedItemRightEnd
+- NoImage / NoImage / ListBoxHiliteSelectedItemRepeatingCenter
+- NoImage / NoImage / ListBoxHiliteSelectedItemSmallRepeatingCenter
+
+### COMBOBOXDROPDOWNBUTTONENABLEDDRAWDATA, COMBOBOXDROPDOWNBUTTONDISABLEDDRAWDATA, COMBOBOXDROPDOWNBUTTONHILITEDRAWDATA
+- VSliderDownButtonEnabled / VSliderDownButtonDisabled / VSliderDownButtonHilite
+- VSliderDownButtonHiliteSelected / NoImage / VSliderDownButtonHiliteSelected
+
+### COMBOBOXEDITBOXENABLEDDRAWDATA, COMBOBOXEDITBOXDISABLEDDRAWDATA, COMBOBOXEDITBOXHILITEDRAWDATA
+- TextEntryEnabledLeftEnd / TextEntryDisabledLeftEnd / TextEntryHiliteLeftEnd
+- TextEntryEnabledRightEnd / TextEntryDisabledRightEnd / TextEntryHiliteRightEnd
+- TextEntryEnabledRepeatingCenter / TextEntryDisabledRepeatingCenter / TextEntryHiliteRepeatingCenter
+- TextEntryEnabledSmallRepeatingCenter / TextEntryDisabledSmallRepeatingCenter / TextEntryHiliteSmallRepeatingCenter
+
+### COMBOBOXLISTBOXENABLEDDRAWDATA, COMBOBOXLISTBOXDISABLEDDRAWDATA, COMBOBOXLISTBOXHILITEDRAWDATA
+- BlackSquare
+- ListBoxHiliteItemLeftEnd / NoImage / ListBoxHiliteSelectedItemLeftEnd
+- ListBoxHiliteItemRightEnd / NoImage / ListBoxHiliteSelectedItemRightEnd
+- ListBoxHiliteItemRepeatingCenter / NoImage / ListBoxHiliteSelectedItemRepeatingCenter
+- ListBoxHiliteItemSmallRepeatingCenter / NoImage / ListBoxHiliteSelectedItemSmallRepeatingCenter
+
+### LISTBOXENABLEDDOWNBUTTONDRAWDATA, LISTBOXDISABLEDDOWNBUTTONDRAWDATA, LISTBOXHILITEDOWNBUTTONDRAWDATA
+- VSliderDownButtonEnabled / VSliderDownButtonDisabled / VSliderDownButtonHilite
+- VSliderDownButtonHiliteSelected / NoImage / VSliderDownButtonHiliteSelected
+
+### LISTBOXENABLEDSLIDERDRAWDATA, LISTBOXDISABLEDSLIDERDRAWDATA, LISTBOXHILITESLIDERDRAWDATA
+- NoImage
+
+### SLIDERTHUMBENABLEDDRAWDATA, SLIDERTHUMBDISABLEDDRAWDATA, SLIDERTHUMBHILITEDRAWDATA
+- ScrollBarThumbEnabled / ScrollBarThumbDisabled / ScrollBarThumbHilite
+- ScrollBarThumbHiliteSelected / NoImage / ScrollBarThumbHiliteSelected
+
+</details>
+
+## Known Issues
+
+1. **Item text color cannot be changed:**  
+   It is currently not possible to change the color of the text (for list items). By default, the text color is white.
+
+2. **Clicking items outside container boundaries:**  
+   If the ComboBox is inside a window container and the list extends beyond the window's boundaries, it is not possible to click on items that are outside of the visible area of the container. This may cause issues when interacting with the ComboBox.
+
+## Example
+Here example from IP address ComboBox in the Options Menu
+<details>
+  <summary>Click to expand</summary>
+
+   ```nasm
+   WINDOW
+     WINDOWTYPE = COMBOBOX;
+     SCREENRECT = UPPERLEFT: 240 464,
+                   BOTTOMRIGHT: 350 489,
+                   CREATIONRESOLUTION: 800 600;
+     NAME = "OptionsMenu.wnd:ComboBoxIP";
+     STATUS = ENABLED+IMAGE;
+     STYLE = MOUSETRACK+COMBOBOX;
+     SYSTEMCALLBACK = "[None]";
+     INPUTCALLBACK = "[None]";
+     TOOLTIPCALLBACK = "[None]";
+     DRAWCALLBACK = "[None]";
+     FONT = NAME: "Arial", SIZE: 10, BOLD: 0;
+     HEADERTEMPLATE = "ComboBoxEntry";
+     TOOLTIPTEXT = "TOOLTIP:LanIP";
+     TOOLTIPDELAY = -1;
+     TEXTCOLOR = ENABLED:  254 254 254 255, ENABLEDBORDER:  0 0 0 255,
+                 DISABLED: 192 192 192 255, DISABLEDBORDER: 64 64 64 255,
+                 HILITE:   128 128 255 255, HILITEBORDER:   0 0 128 255;
+     ENABLEDDRAWDATA = IMAGE: NoImage, COLOR: 255 0 0 255, BORDERCOLOR: 255 128 128 255,
+                       IMAGE: NoImage, COLOR: 47 55 168 255, BORDERCOLOR: 254 254 254 255,
+                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
+     DISABLEDDRAWDATA = IMAGE: NoImage, COLOR: 128 128 128 255, BORDERCOLOR: 192 192 192 255,
+                         IMAGE: NoImage, COLOR: 192 192 192 255, BORDERCOLOR: 254 254 254 255,
+                         IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                         IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                         IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                         IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                         IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                         IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                         IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
+     HILITEDRAWDATA = IMAGE: NoImage, COLOR: 0 255 0 255, BORDERCOLOR: 0 128 0 255,
+                       IMAGE: ListBoxHiliteSelectedItemLeftEnd, COLOR: 254 254 254 255, BORDERCOLOR: 0 128 0 255,
+                       IMAGE: ListBoxHiliteSelectedItemRightEnd, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                       IMAGE: ListBoxHiliteSelectedItemRepeatingCenter, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                       IMAGE: ListBoxHiliteSelectedItemSmallRepeatingCenter, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
+     COMBOBOXDATA = ISEDITABLE: 0,
+                   MAXCHARS: 16,
+                   MAXDISPLAY: 2,
+                   ASCIIONLY: 0,
+                   LETTERSANDNUMBERS: 0;
+     COMBOBOXDROPDOWNBUTTONENABLEDDRAWDATA = IMAGE: VSliderDownButtonEnabled, COLOR: 255 0 0 255, BORDERCOLOR: 255 128 128 255,
+                                             IMAGE: VSliderDownButtonHiliteSelected, COLOR: 255 255 0 255, BORDERCOLOR: 254 254 254 255,
+                                             IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                             IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                             IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                             IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                             IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                             IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                             IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
+     COMBOBOXDROPDOWNBUTTONDISABLEDDRAWDATA = IMAGE: VSliderDownButtonDisabled, COLOR: 128 128 128 255, BORDERCOLOR: 192 192 192 255,
+                                               IMAGE: NoImage, COLOR: 192 192 192 255, BORDERCOLOR: 128 128 128 255,
+                                               IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                               IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                               IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                               IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                               IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                               IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                               IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
+     COMBOBOXDROPDOWNBUTTONHILITEDRAWDATA = IMAGE: VSliderDownButtonHilite, COLOR: 0 255 0 255, BORDERCOLOR: 0 128 0 255,
+                                             IMAGE: VSliderDownButtonHiliteSelected, COLOR: 255 255 0 255, BORDERCOLOR: 254 254 254 255,
+                                             IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                             IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                             IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                             IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                             IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                             IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                             IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
+     COMBOBOXEDITBOXENABLEDDRAWDATA = IMAGE: TextEntryEnabledLeftEnd, COLOR: 255 0 0 255, BORDERCOLOR: 255 128 128 255,
+                                       IMAGE: TextEntryEnabledRightEnd, COLOR: 255 255 0 255, BORDERCOLOR: 254 254 254 255,
+                                       IMAGE: TextEntryEnabledRepeatingCenter, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: TextEntryEnabledSmallRepeatingCenter, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
+     COMBOBOXEDITBOXDISABLEDDRAWDATA = IMAGE: TextEntryDisabledLeftEnd, COLOR: 128 128 128 255, BORDERCOLOR: 0 0 0 255,
+                                       IMAGE: TextEntryDisabledRightEnd, COLOR: 192 192 192 255, BORDERCOLOR: 254 254 254 255,
+                                       IMAGE: TextEntryDisabledRepeatingCenter, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: TextEntryDisabledSmallRepeatingCenter, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
+     COMBOBOXEDITBOXHILITEDRAWDATA = IMAGE: TextEntryHiliteLeftEnd, COLOR: 0 255 0 255, BORDERCOLOR: 0 128 0 255,
+                                     IMAGE: TextEntryHiliteRightEnd, COLOR: 254 254 254 255, BORDERCOLOR: 0 128 0 255,
+                                     IMAGE: TextEntryHiliteRepeatingCenter, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: TextEntryHiliteSmallRepeatingCenter, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
+     COMBOBOXLISTBOXENABLEDDRAWDATA = IMAGE: BlackSquare, COLOR: 0 0 0 255, BORDERCOLOR: 49 55 168 255,
+                                       IMAGE: ListBoxHiliteItemLeftEnd, COLOR: 255 255 0 255, BORDERCOLOR: 254 254 254 255,
+                                       IMAGE: ListBoxHiliteItemRightEnd, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: ListBoxHiliteItemRepeatingCenter, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: ListBoxHiliteItemSmallRepeatingCenter, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
+     COMBOBOXLISTBOXDISABLEDDRAWDATA = IMAGE: BlackSquare, COLOR: 0 0 0 255, BORDERCOLOR: 49 55 168 255,
+                                       IMAGE: NoImage, COLOR: 192 192 192 255, BORDERCOLOR: 254 254 254 255,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
+     COMBOBOXLISTBOXHILITEDRAWDATA = IMAGE: BlackSquare, COLOR: 0 0 0 255, BORDERCOLOR: 49 55 168 255,
+                                     IMAGE: ListBoxHiliteSelectedItemLeftEnd, COLOR: 254 254 254 255, BORDERCOLOR: 0 128 0 255,
+                                     IMAGE: ListBoxHiliteSelectedItemRightEnd, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: ListBoxHiliteSelectedItemRepeatingCenter, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: ListBoxHiliteSelectedItemSmallRepeatingCenter, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
+     LISTBOXENABLEDUPBUTTONDRAWDATA = IMAGE: VSliderUpButtonEnabled, COLOR: 255 0 0 255, BORDERCOLOR: 255 128 128 255,
+                                       IMAGE: VSliderUpButtonHiliteSelected, COLOR: 255 255 0 255, BORDERCOLOR: 254 254 254 255,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
+     LISTBOXDISABLEDUPBUTTONDRAWDATA = IMAGE: VSliderUpButtonDisabled, COLOR: 128 128 128 255, BORDERCOLOR: 192 192 192 255,
+                                       IMAGE: NoImage, COLOR: 192 192 192 255, BORDERCOLOR: 254 254 254 255,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
+     LISTBOXHILITEUPBUTTONDRAWDATA = IMAGE: VSliderUpButtonHilite, COLOR: 0 255 0 255, BORDERCOLOR: 0 128 0 255,
+                                     IMAGE: VSliderUpButtonHiliteSelected, COLOR: 254 254 254 255, BORDERCOLOR: 0 128 0 255,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
+     LISTBOXENABLEDDOWNBUTTONDRAWDATA = IMAGE: VSliderDownButtonEnabled, COLOR: 255 0 0 255, BORDERCOLOR: 255 128 128 255,
+                                         IMAGE: VSliderDownButtonHiliteSelected, COLOR: 255 255 0 255, BORDERCOLOR: 254 254 254 255,
+                                         IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                         IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                         IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                         IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                         IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                         IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                         IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
+     LISTBOXDISABLEDDOWNBUTTONDRAWDATA = IMAGE: VSliderDownButtonDisabled, COLOR: 128 128 128 255, BORDERCOLOR: 192 192 192 255,
+                                         IMAGE: NoImage, COLOR: 192 192 192 255, BORDERCOLOR: 254 254 254 255,
+                                         IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                         IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                         IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                         IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                         IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                         IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                         IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
+     LISTBOXHILITEDOWNBUTTONDRAWDATA = IMAGE: VSliderDownButtonHilite, COLOR: 0 255 0 255, BORDERCOLOR: 0 128 0 255,
+                                       IMAGE: VSliderDownButtonHiliteSelected, COLOR: 254 254 254 255, BORDERCOLOR: 0 128 0 255,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                       IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
+     LISTBOXENABLEDSLIDERDRAWDATA = IMAGE: NoImage, COLOR: 168 255 12 0, BORDERCOLOR: 47 55 168 255,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
+     LISTBOXDISABLEDSLIDERDRAWDATA = IMAGE: NoImage, COLOR: 128 128 128 0, BORDERCOLOR: 148 112 0 255,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
+     LISTBOXHILITESLIDERDRAWDATA = IMAGE: NoImage, COLOR: 0 255 0 0, BORDERCOLOR: 49 55 168 255,
+                                   IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                   IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                   IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                   IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                   IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                   IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                   IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                   IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
+     SLIDERTHUMBENABLEDDRAWDATA = IMAGE: ScrollBarThumbEnabled, COLOR: 255 4 0 0, BORDERCOLOR: 255 243 28 255,
+                                   IMAGE: ScrollBarThumbHiliteSelected, COLOR: 255 255 0 255, BORDERCOLOR: 254 254 254 255,
+                                   IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                   IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                   IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                   IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                   IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                   IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                   IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
+     SLIDERTHUMBDISABLEDDRAWDATA = IMAGE: ScrollBarThumbDisabled, COLOR: 128 128 128 255, BORDERCOLOR: 192 192 192 255,
+                                   IMAGE: NoImage, COLOR: 192 192 192 255, BORDERCOLOR: 254 254 254 255,
+                                   IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                   IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                   IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                   IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                   IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                   IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                   IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
+     SLIDERTHUMBHILITEDRAWDATA = IMAGE: ScrollBarThumbHilite, COLOR: 0 255 0 255, BORDERCOLOR: 0 128 0 255,
+                                 IMAGE: ScrollBarThumbHiliteSelected, COLOR: 254 254 254 255, BORDERCOLOR: 0 128 0 255,
+                                 IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                 IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                 IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                 IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                 IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                 IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                                 IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
+   END
+   ```
+
+</details>
+
+## See also
+* [Default control](user.md)
+* [Texturing](../texturing.md)
+
+[Category:](../Categories.md) [Controls](../Controls.md)

--- a/documents/wnd/controls/user.md
+++ b/documents/wnd/controls/user.md
@@ -1,0 +1,107 @@
+# USER Control
+
+The **USER** control is the default control type, used for multiple purposes. It can serve as a container or group for other controls, as well as a tool for drawing rectangular shapes or lines by defining their position. Other controls also use the tags defined for the **USER** control, in addition to their own specific tags.
+
+## Purposes of the Control:
+1. **Container/Group**:  
+   The **USER** control can act as a container, holding and organizing other controls. This allows for efficient layout and management of multiple elements on the screen.
+
+2. **Drawing Rectangles or Lines**:  
+   It can also be used to draw rectangular shapes or lines by specifying the position and dimensions, making it useful for creating visual boundaries or shapes within the UI.
+
+### Opening and Closing a Control:
+
+Each control is opened with the keyword `WINDOW` and closed with the keyword `END`.
+
+For the **USER** control, when it serves as a container (group), it can contain other controls as children. Each child control is preceded by the keyword `CHILD`, and after all the children have been defined, the keyword `ENDALLCHILDREN` should be used to close the group of children and return to the main control.
+
+#### Example with Children:
+```nasm
+WINDOW
+  WINDOWTYPE = USER ; parent
+  ... rest of control options
+  CHILD
+  WINDOW ; child
+    WINDOWTYPE = CHECKBOX
+    ... rest of control child options
+  END
+  CHILD
+  WINDOW ; child
+    WINDOWTYPE = COMBOBOXDATA
+    ... rest of control child options
+  END
+  WINDOW ; child and parent or just drawing
+    WINDOWTYPE = USER
+    ... rest of control child options
+  END
+  ENDALLCHILDREN
+END
+```
+
+## Available Tags:
+The following tags are available for the **USER** control:
+
+| Tag                                                           | Description                                                                                                  |
+|---------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
+| `WINDOWTYPE`                                                  | The control type.                                                                                            |
+| `SCREENRECT`                                                  | Defines the size and position of the control on the screen.                                                  |
+| `NAME`                                                        | The name of the control.                                                                                     |
+| `STATUS`                                                      | The status of the control. see [status](../status.md)                                                        |
+| `STYLE`                                                       | The style of the control. see [styles](../style.md).                                                         |
+| `SYSTEMCALLBACK`                                              | The system callback function for the control. see [callbacks](../callbacks.md).                              |
+| `INPUTCALLBACK`                                               | The input callback function for the control.                                                                 |
+| `TOOLTIPCALLBACK`                                             | Callback function for the control’s tooltip.                                                                 |
+| `DRAWCALLBACK`                                                | Callback function for the control’s texture.                                                                 |
+| `FONT`                                                        | Font settings. see [Text Properties](../text_properties.md).                                                 |
+| `HEADERTEMPLATE` (Optional)                                   | Defines the template for the control’s text. see [Text Properties](../text_properties.md).                   |
+| `TOOLTIPTEXT` (Optional)                                      | Text for the tooltip displayed when hovering over the control. see [Text Properties](../text_properties.md). |
+| `TOOLTIPDELAY`                                                | Delay `0...n` time for the tooltip to appear, `-1` for disable.                                              |
+| `TEXT` (Optional)                                             | The text displayed in the control. see [Text Properties](../text_properties.md).                             |
+| `TEXTCOLOR`                                                   | Color settings for text in different states. see [Text Properties](../text_properties.md).                   |
+| `ENABLEDDRAWDATA`,<br>`DISABLEDDRAWDATA`,<br>`HILITEDRAWDATA` | Visual texture for the control in different states                                                           |
+
+<small>Note: All tags are case-sensitive.</small>
+
+<small>Note: The order of the tags is crucial for proper rendering of the control and must be followed as specified.</small>
+
+
+## Example
+
+Here’s a sample code defining a **USER** control:
+
+```nasm
+WINDOW
+  WINDOWTYPE = USER;
+  SCREENRECT = UPPERLEFT: 140 20,
+               BOTTOMRIGHT: 660 544,
+               CREATIONRESOLUTION: 800 600;
+  NAME = "OptionsMenu.wnd:OptionsMenuParent";
+  STATUS = ENABLED+NOFOCUS+SEE_THRU;
+  STYLE = USER;
+  SYSTEMCALLBACK = "OptionsMenuSystem";
+  INPUTCALLBACK = "OptionsMenuInput";
+  TOOLTIPCALLBACK = "[None]";
+  DRAWCALLBACK = "[None]";
+  FONT = NAME: "Times New Roman", SIZE: 14, BOLD: 0;
+  HEADERTEMPLATE = "[NONE]";
+  TOOLTIPDELAY = -1;
+  TEXTCOLOR = ENABLED:  255 255 255 0, ENABLEDBORDER:  255 255 255 0,
+              DISABLED: 255 255 255 0, DISABLEDBORDER: 255 255 255 0,
+              HILITE:   255 255 255 0, HILITEBORDER:   255 255 255 0;
+  ENABLEDDRAWDATA = IMAGE: NoImage, COLOR: 0 0 0 255, BORDERCOLOR: 0 0 0 255,
+                    IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                    IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
+  DISABLEDDRAWDATA = IMAGE: NoImage, COLOR: 0 0 64 255, BORDERCOLOR: 0 0 0 255,
+                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                     IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
+  HILITEDRAWDATA = IMAGE: NoImage, COLOR: 0 0 255 255, BORDERCOLOR: 0 0 0 255,
+                   IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0,
+                   IMAGE: NoImage, COLOR: 255 255 255 0, BORDERCOLOR: 255 255 255 0;
+END
+```
+
+## See Also
+* [callbacks](../callbacks.md)
+* [Texturing](../texturing.md)
+
+[Category:](../Categories.md) [Controls](../Controls.md)


### PR DESCRIPTION
This pull request introduces new wiki pages for `.wnd` files, offering comprehensive documentation on various control types and their structure. It also clarifies the usage of key attributes such as **callbacks** and **status**. The new documentation covers:

1. How to define and structure different control types within a `.wnd` file.
2. The proper usage of essential attributes like `WINDOWTYPE`, `SCREENRECT`, `NAME`, `STATUS`, and others for each control.
3. Explanation of **callback functions** used for different events such as system callbacks, input callbacks, tooltip callbacks, and drawing callbacks.
4. Detailed information on the **STATUS** attribute, outlining different control states (e.g., `ENABLED`, `HIDDEN`) and how they affect control behavior and appearance.
5. How to manage parent-child relationships between controls, including the use of the `CHILD` and `ENDALLCHILDREN` keywords.
6. Configuration of visual properties, including fonts, colors, and textures.
